### PR TITLE
Add int4range

### DIFF
--- a/lib/int4range.ex
+++ b/lib/int4range.ex
@@ -1,4 +1,8 @@
-defmodule Ecto.Int4range do
+defmodule Ecto.Int4Range do
+  @moduledoc """
+  A Postgres range of `int4` integers. Equivalent to `int4range`.
+  """
+
   use Ecto.Type
 
   @int4_range -2_147_483_648..2_147_483_647
@@ -29,30 +33,56 @@ defmodule Ecto.Int4range do
     {:ok, normalize_range(range)}
   end
 
-  defp to_postgrex_range(%Postgrex.Range{lower: lower, upper: upper} = range)
-       when lower in @int4_range and upper in @int4_range do
-    range
-  end
+  @doc """
+  Checks and converts a `Postgrex.Range` or tuple into a `Postgrex.Range.t()`
 
-  defp to_postgrex_range({lower, upper})
-       when lower in @int4_range and upper in @int4_range do
-    %Postgrex.Range{
+  ## Examples
+
+      iex> Ecto.DateRange.to_postgrex_range({1, 3})
+      %Postgrex.Range{lower: 1, upper: 3, lower_inclusive: true, upper_inclusive: true}
+
+  """
+  @spec to_postgrex_range(Postgrex.Range.t() | {integer(), integer()}) ::
+          Postgrex.Range.t() | :error
+  def to_postgrex_range({lower, upper}) do
+    range = %Postgrex.Range{
       lower: if(is_nil(lower), do: :unbound, else: lower),
       upper: if(is_nil(upper), do: :unbound, else: upper),
       lower_inclusive: true,
       upper_inclusive: true
     }
+
+    to_postgrex_range(range)
   end
 
-  defp to_postgrex_range(_), do: :error
+  def to_postgrex_range(%Postgrex.Range{lower: lower, upper: upper} = range)
+      when lower in @int4_range and upper in @int4_range do
+    {:ok, range}
+  end
 
-  defp normalize_range(%Postgrex.Range{upper: upper, lower: lower} = range) do
+  def to_postgrex_range(_), do: :error
+
+  @doc """
+  Converts a Postgrex.Range.t() into a normalized form. For bounded ranges,
+  it will make the lower and upper bounds inclusive.
+
+      iex> range = %Postgrex.Range{lower: 1, upper: 3, lower_inclusive: true, upper_inclusive: false}
+      iex> Ecto.Int4Range.normalize_range(range)
+      %Postgrex.Range{lower: 1, upper: 2, lower_inclusive: true, upper_inclusive: true}
+
+      iex> range = %Postgrex.Range{lower: 1, upper: 3, lower_inclusive: false, upper_inclusive: true}
+      iex> Ecto.Int4Range.normalize_range(range)
+      %Postgrex.Range{lower: 2, upper: 3, lower_inclusive: true, upper_inclusive: true}
+
+  """
+  def normalize_range(%Postgrex.Range{lower: lower, upper: upper} = range)
+      when is_integer(lower) and is_integer(upper) do
     range
     |> normalize_upper()
     |> normalize_lower()
   end
 
-  defp normalize_range(%Postgrex.Range{} = range), do: range
+  def normalize_range(%Postgrex.Range{} = range), do: range
 
   defp normalize_upper(%Postgrex.Range{} = range) do
     if range.upper_inclusive do

--- a/lib/int4range.ex
+++ b/lib/int4range.ex
@@ -1,0 +1,72 @@
+defmodule Ecto.Int4range do
+  use Ecto.Type
+
+  @int4_range -2_147_483_648..2_147_483_647
+
+  @impl Ecto.Type
+  def type, do: :int4range
+
+  @impl Ecto.Type
+  def cast(%Postgrex.Range{} = range) do
+    to_postgrex_range(range)
+  end
+
+  def cast({lower, upper}) do
+    to_postgrex_range({lower, upper})
+  end
+
+  def cast(_), do: :error
+
+  @impl Ecto.Type
+  def dump(%Postgrex.Range{} = range) do
+    {:ok, range}
+  end
+
+  def dump(_), do: :error
+
+  @impl Ecto.Type
+  def load(%Postgrex.Range{} = range) do
+    {:ok, normalize_range(range)}
+  end
+
+  defp to_postgrex_range(%Postgrex.Range{lower: lower, upper: upper} = range)
+       when lower in @int4_range and upper in @int4_range do
+    range
+  end
+
+  defp to_postgrex_range({lower, upper})
+       when lower in @int4_range and upper in @int4_range do
+    %Postgrex.Range{
+      lower: if(is_nil(lower), do: :unbound, else: lower),
+      upper: if(is_nil(upper), do: :unbound, else: upper),
+      lower_inclusive: true,
+      upper_inclusive: true
+    }
+  end
+
+  defp to_postgrex_range(_), do: :error
+
+  defp normalize_range(%Postgrex.Range{upper: upper, lower: lower} = range) do
+    range
+    |> normalize_upper()
+    |> normalize_lower()
+  end
+
+  defp normalize_range(%Postgrex.Range{} = range), do: range
+
+  defp normalize_upper(%Postgrex.Range{} = range) do
+    if range.upper_inclusive do
+      range
+    else
+      %{range | upper_inclusive: true, upper: range.upper - 1}
+    end
+  end
+
+  defp normalize_lower(%Postgrex.Range{} = range) do
+    if range.lower_inclusive do
+      range
+    else
+      %{range | lower_inclusive: true, lower: range.lower + 1}
+    end
+  end
+end

--- a/lib/int4range.ex
+++ b/lib/int4range.ex
@@ -11,12 +11,14 @@ defmodule Ecto.Int4Range do
   def type, do: :int4range
 
   @impl Ecto.Type
-  def cast(%Postgrex.Range{} = range) do
-    to_postgrex_range(range)
+  def cast(%Postgrex.Range{lower: lower, upper: upper} = range)
+      when lower in @int4_range and upper in @int4_range do
+    {:ok, to_postgrex_range(range)}
   end
 
-  def cast({lower, upper}) do
-    to_postgrex_range({lower, upper})
+  def cast({lower, upper})
+      when lower in @int4_range and upper in @int4_range do
+    {:ok, to_postgrex_range({lower, upper})}
   end
 
   def cast(_), do: :error
@@ -43,24 +45,17 @@ defmodule Ecto.Int4Range do
 
   """
   @spec to_postgrex_range(Postgrex.Range.t() | {integer(), integer()}) ::
-          Postgrex.Range.t() | :error
+          Postgrex.Range.t()
+  def to_postgrex_range(%Postgrex.Range{} = range), do: range
+
   def to_postgrex_range({lower, upper}) do
-    range = %Postgrex.Range{
+    %Postgrex.Range{
       lower: if(is_nil(lower), do: :unbound, else: lower),
       upper: if(is_nil(upper), do: :unbound, else: upper),
       lower_inclusive: true,
       upper_inclusive: true
     }
-
-    to_postgrex_range(range)
   end
-
-  def to_postgrex_range(%Postgrex.Range{lower: lower, upper: upper} = range)
-      when lower in @int4_range and upper in @int4_range do
-    {:ok, range}
-  end
-
-  def to_postgrex_range(_), do: :error
 
   @doc """
   Converts a Postgrex.Range.t() into a normalized form. For bounded ranges,

--- a/priv/repo/migrations/20221011011012_test_app.exs
+++ b/priv/repo/migrations/20221011011012_test_app.exs
@@ -5,6 +5,7 @@ defmodule TestApp.Repo.Migrations.TestApp do
     create table(:my_table) do
       add :name, :string
       add :range, :daterange
+      add :int4range, :int4range
     end
   end
 end

--- a/test/int4range_test.exs
+++ b/test/int4range_test.exs
@@ -1,0 +1,40 @@
+defmodule Ecto.Int4rangeTest do
+  use Ecto.DateRange.DataCase
+
+  describe "cast/1" do
+    test "it can take a Postgrex.Range.t()" do
+      range = %Postgrex.Range{
+        lower: 1,
+        upper: 3,
+        upper_inclusive: true,
+        lower_inclusive: false
+      }
+
+      assert Ecto.Int4range.cast(range) == {:ok, range}
+    end
+
+    test "it can take a tuple" do
+      range = {1, 3}
+
+      assert Ecto.Int4range.cast(range) ==
+               {:ok,
+                %Postgrex.Range{
+                  lower: 1,
+                  upper: 3,
+                  upper_inclusive: true,
+                  lower_inclusive: true
+                }}
+    end
+
+    test "it blocks values not in the Int4 range" do
+      range = %Postgrex.Range{
+        lower: -2_147_483_649,
+        upper: 2_147_483_648,
+        upper_inclusive: true,
+        lower_inclusive: false
+      }
+
+      assert Ecto.Int4range.cast(range) == :error
+    end
+  end
+end

--- a/test/int4range_test.exs
+++ b/test/int4range_test.exs
@@ -1,4 +1,4 @@
-defmodule Ecto.Int4rangeTest do
+defmodule Ecto.Int4RangeTest do
   use Ecto.DateRange.DataCase
 
   describe "cast/1" do
@@ -10,13 +10,13 @@ defmodule Ecto.Int4rangeTest do
         lower_inclusive: false
       }
 
-      assert Ecto.Int4range.cast(range) == {:ok, range}
+      assert Ecto.Int4Range.cast(range) == {:ok, range}
     end
 
     test "it can take a tuple" do
       range = {1, 3}
 
-      assert Ecto.Int4range.cast(range) ==
+      assert Ecto.Int4Range.cast(range) ==
                {:ok,
                 %Postgrex.Range{
                   lower: 1,
@@ -34,7 +34,7 @@ defmodule Ecto.Int4rangeTest do
         lower_inclusive: false
       }
 
-      assert Ecto.Int4range.cast(range) == :error
+      assert Ecto.Int4Range.cast(range) == :error
     end
   end
 end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -1,4 +1,4 @@
-defmodule EctoDateRange.IntegrationTest do
+defmodule Ecto.DateRange.IntegrationTest do
   use Ecto.DateRange.DataCase
 
   alias TestApp.Table
@@ -116,6 +116,32 @@ defmodule EctoDateRange.IntegrationTest do
              id: ^id,
              name: "a"
            } = TestApp.Repo.get!(Table, id)
+  end
+
+  describe "int4range" do
+    test "can round trip a range through the database" do
+      range = %Postgrex.Range{
+        lower: 1,
+        upper: 3,
+        lower_inclusive: true,
+        upper_inclusive: true
+      }
+
+      assert %Table{id: id} = TestApp.Repo.insert!(%Table{name: "a", int4range: range})
+      assert %TestApp.Table{id: ^id, int4range: ^range, name: "a"} = TestApp.Repo.get!(Table, id)
+    end
+
+    test "returns an error if integers outside the int4 range are given" do
+      range = %Postgrex.Range{
+        lower: -2_147_483_649,
+        upper: 2_147_483_648,
+        lower_inclusive: true,
+        upper_inclusive: true
+      }
+
+      assert {:error, error} = TestApp.Context.create_table(%{name: "a", int4range: range})
+      assert [int4range: {"is invalid", [type: Ecto.Int4range, validation: :cast]}] = error.errors
+    end
   end
 
   def range(_context \\ %{}) do

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -6,22 +6,22 @@ defmodule Ecto.DateRange.IntegrationTest do
   test "it can cast new data" do
     %{first: first, last: last} = range = range()
 
-    assert Table.changeset(%Table{}, %{name: "name", range: range}) == %Ecto.Changeset{
+    changeset = Table.changeset(%Table{}, %{name: "name", range: range})
+
+    assert %Ecto.Changeset{
              changes: %{
                range: %Postgrex.Range{
-                 lower: first,
-                 upper: last,
+                 lower: ^first,
+                 upper: ^last,
                  lower_inclusive: true,
                  upper_inclusive: true
                },
                name: "name"
              },
-             required: [:name, :range],
              data: %TestApp.Table{id: nil, name: nil, range: nil},
-             params: %{"range" => Date.range(first, last), "name" => "name"},
-             types: %{range: Ecto.DateRange, id: :id, name: :string},
+             params: %{"range" => ^range, "name" => "name"},
              valid?: true
-           }
+           } = changeset
   end
 
   test "it can cast against existing data" do
@@ -29,32 +29,33 @@ defmodule Ecto.DateRange.IntegrationTest do
              cs = Table.changeset(%Table{}, %{name: "name", range: range()})
 
     assert %Table{} = t = Ecto.Changeset.apply_changes(cs)
+    range = Date.range(~D[2020-01-01], ~D[2020-12-31])
 
-    assert Table.changeset(t, %{range: Date.range(~D[2020-01-01], ~D[2020-12-31])}) ==
-             %Ecto.Changeset{
-               changes: %{
-                 range: %Postgrex.Range{
-                   lower: ~D[2020-01-01],
-                   upper: ~D[2020-12-31],
-                   lower_inclusive: true,
-                   upper_inclusive: true
-                 }
-               },
-               data: %TestApp.Table{
-                 id: nil,
-                 name: "name",
-                 range: %Postgrex.Range{
-                   lower: ~D[1989-09-22],
-                   upper: ~D[2021-03-01],
-                   lower_inclusive: true,
-                   upper_inclusive: true
-                 }
-               },
-               params: %{"range" => Date.range(~D[2020-01-01], ~D[2020-12-31])},
-               required: [:name, :range],
-               types: %{range: Ecto.DateRange, id: :id, name: :string},
-               valid?: true
-             }
+    changeset = Table.changeset(t, %{range: range})
+
+    assert %Ecto.Changeset{
+             changes: %{
+               range: %Postgrex.Range{
+                 lower: ~D[2020-01-01],
+                 upper: ~D[2020-12-31],
+                 lower_inclusive: true,
+                 upper_inclusive: true
+               }
+             },
+             data: %TestApp.Table{
+               id: nil,
+               name: "name",
+               range: %Postgrex.Range{
+                 lower: ~D[1989-09-22],
+                 upper: ~D[2021-03-01],
+                 lower_inclusive: true,
+                 upper_inclusive: true
+               }
+             },
+             params: %{"range" => ^range},
+             required: [:name],
+             valid?: true
+           } = changeset
   end
 
   test "can round trip Date.Range through the database" do
@@ -140,7 +141,7 @@ defmodule Ecto.DateRange.IntegrationTest do
       }
 
       assert {:error, error} = TestApp.Context.create_table(%{name: "a", int4range: range})
-      assert [int4range: {"is invalid", [type: Ecto.Int4range, validation: :cast]}] = error.errors
+      assert [int4range: {"is invalid", [type: Ecto.Int4Range, validation: :cast]}] = error.errors
     end
   end
 

--- a/test/support/test_app/context.ex
+++ b/test/support/test_app/context.ex
@@ -1,0 +1,10 @@
+defmodule TestApp.Context do
+  alias TestApp.Table
+  alias TestApp.Repo
+
+  def create_table(attrs) do
+    %Table{}
+    |> Table.changeset(attrs)
+    |> Repo.insert()
+  end
+end

--- a/test/support/test_app/context.ex
+++ b/test/support/test_app/context.ex
@@ -1,4 +1,6 @@
 defmodule TestApp.Context do
+  @moduledoc false
+
   alias TestApp.Table
   alias TestApp.Repo
 

--- a/test/support/test_app/table.ex
+++ b/test/support/test_app/table.ex
@@ -7,7 +7,7 @@ defmodule TestApp.Table do
   schema "my_table" do
     field(:name, :string)
     field(:range, Ecto.DateRange)
-    field(:int4range, Ecto.Int4range)
+    field(:int4range, Ecto.Int4Range)
   end
 
   def changeset(table, params) do

--- a/test/support/test_app/table.ex
+++ b/test/support/test_app/table.ex
@@ -7,11 +7,12 @@ defmodule TestApp.Table do
   schema "my_table" do
     field(:name, :string)
     field(:range, Ecto.DateRange)
+    field(:int4range, Ecto.Int4range)
   end
 
   def changeset(table, params) do
     table
-    |> cast(params, [:name, :range])
-    |> validate_required([:name, :range])
+    |> cast(params, [:name, :range, :int4range])
+    |> validate_required([:name])
   end
 end


### PR DESCRIPTION
I used the [int4](https://github.com/elixir-ecto/postgrex/blob/8e4f0ec9ad23fac05b21439642c6ba2e30cad8a5/lib/postgrex/extensions/int4.ex) type to create a [int4range](https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-BUILTIN). It seems to be working!

Some thoughts about my experience of extending the current library:

1. I copy&pasted the `to_postgrex_range/1` and `normalize_range/1` functions to the new module. It would be nice to have a `Utils` or `Normalize` or `ParseUtils` or similar module where we could move these functions,so that we don't have to duplicate them to every new type. I can whip up something if you like 👍 
2. File structure wise, it might be helpful to move all range types into a dedicated `ranges` folder. So: `lib/ranges/int4range.ex` and `lib/ranges/daterange.ex`. Just a thought.
3. The test setup is already pretty good. One thought here would be to also move the type tests to a `ranges` folder. Another thought is whether we want to split the `integrations_test` into multiple files or keep all of them in a single file. I'm okay with both.

Please review and let me know what you think :)